### PR TITLE
Safe support

### DIFF
--- a/packages/nextjs/app/_components/SignMessage.tsx
+++ b/packages/nextjs/app/_components/SignMessage.tsx
@@ -3,21 +3,28 @@
 import LoadingButton from "./LoadingButton";
 import { useConnectModal } from "@rainbow-me/rainbowkit";
 import { useAccount, useSignMessage } from "wagmi";
+import { notification } from "~~/utils/scaffold-eth/notification";
 
 type SignMessageProps = {
   messageText: string;
   setMessageText: (value: string) => void;
   onSign: (signature: string) => void;
+  isSubmitting?: boolean;
 };
 
-export const SignMessage = ({ messageText, setMessageText, onSign }: SignMessageProps) => {
+export const SignMessage = ({ messageText, setMessageText, onSign, isSubmitting = false }: SignMessageProps) => {
   const { isConnected } = useAccount();
   const { openConnectModal } = useConnectModal();
   const { signMessageAsync, isPending } = useSignMessage();
 
   const handleSign = async () => {
-    const signature = await signMessageAsync({ message: messageText });
-    onSign(signature);
+    try {
+      const signature = await signMessageAsync({ message: messageText });
+      onSign(signature);
+    } catch (err) {
+      const errorMessage = err instanceof Error ? err.message : "User rejected the signature request";
+      notification.error(errorMessage);
+    }
   };
 
   return (
@@ -25,8 +32,8 @@ export const SignMessage = ({ messageText, setMessageText, onSign }: SignMessage
       <textarea className="textarea" value={messageText} onChange={e => setMessageText(e.target.value)} />
       <LoadingButton
         onClick={isConnected ? handleSign : openConnectModal}
-        disabled={isPending}
-        isLoading={isPending}
+        disabled={isPending || isSubmitting}
+        isLoading={isPending || isSubmitting}
         loadingText="Signing..."
         defaultText={isConnected ? "Sign Message" : "Connect Wallet"}
       />

--- a/packages/nextjs/app/_components/SignTypedData.tsx
+++ b/packages/nextjs/app/_components/SignTypedData.tsx
@@ -5,6 +5,7 @@ import { TypedDataChecks } from "./types";
 import { useConnectModal } from "@rainbow-me/rainbowkit";
 import { useAccount, useSignTypedData } from "wagmi";
 import { ExclamationCircleIcon } from "@heroicons/react/24/outline";
+import { notification } from "~~/utils/scaffold-eth/notification";
 
 type TypedDataProps = {
   manualTypedData: string;
@@ -16,6 +17,7 @@ type TypedDataProps = {
   typedDataChecks: TypedDataChecks;
   setTypedDataChecks: (checks: TypedDataChecks) => void;
   onSign: (signature: string) => void;
+  isSubmitting?: boolean;
 };
 
 export const SignTypedData = ({
@@ -28,6 +30,7 @@ export const SignTypedData = ({
   typedDataChecks,
   setTypedDataChecks,
   onSign,
+  isSubmitting = false,
 }: TypedDataProps) => {
   const { isConnected } = useAccount();
   const { openConnectModal } = useConnectModal();
@@ -48,8 +51,13 @@ export const SignTypedData = ({
 
   const handleSignTypedData = async () => {
     if (!typedDataChecks.hash) return;
-    const signature = await signTypedDataAsync(typedData);
-    onSign(signature);
+    try {
+      const signature = await signTypedDataAsync(typedData);
+      onSign(signature);
+    } catch (err) {
+      const errorMessage = err instanceof Error ? err.message : "User rejected the signature request";
+      notification.error(errorMessage);
+    }
   };
 
   return (
@@ -67,8 +75,8 @@ export const SignTypedData = ({
 
       <LoadingButton
         onClick={isConnected ? handleSignTypedData : openConnectModal}
-        disabled={isPending}
-        isLoading={isPending}
+        disabled={isPending || isSubmitting}
+        isLoading={isPending || isSubmitting}
         loadingText="Signing..."
         defaultText={isConnected ? "Sign Typed Data" : "Connect Wallet"}
       />

--- a/packages/nextjs/app/_components/types.ts
+++ b/packages/nextjs/app/_components/types.ts
@@ -1,4 +1,8 @@
 export const eip712Example = {
+  domain: {
+    name: "Signator.IO",
+    version: "1",
+  },
   types: {
     Greeting: [
       { name: "salutation", type: "string" },

--- a/packages/nextjs/app/api/signatures/route.ts
+++ b/packages/nextjs/app/api/signatures/route.ts
@@ -2,9 +2,11 @@ import { NextRequest, NextResponse } from "next/server";
 import { isAddress, isHex, recoverMessageAddress, recoverTypedDataAddress } from "viem";
 import { createMessageWithSignature } from "~~/services/db";
 import { messageTypeEnum } from "~~/services/db/schema";
+import { isContractAddress } from "~~/utils/signatorio/detect-safe";
+import { validateSafeSignature } from "~~/utils/signatorio/validate-safe-signature";
 
 export const POST = async (req: NextRequest) => {
-  const { signature, message, messageType, address } = await req.json();
+  const { signature, message, messageType, address, chainId } = await req.json();
 
   if (!signature || !message || !messageType || !address) {
     return NextResponse.json({ error: "Missing required parameters" }, { status: 400 });
@@ -22,13 +24,40 @@ export const POST = async (req: NextRequest) => {
     return NextResponse.json({ error: "Invalid message type" }, { status: 400 });
   }
 
-  const recoveredAddress =
-    messageType === "typed_data"
-      ? await recoverTypedDataAddress({ ...JSON.parse(message), signature })
-      : await recoverMessageAddress({ message, signature });
+  if (chainId === undefined || chainId === null) {
+    return NextResponse.json({ error: "chainId is required" }, { status: 400 });
+  }
 
-  if (recoveredAddress !== address) {
-    return NextResponse.json({ error: "Invalid signature" }, { status: 401 });
+  if (typeof chainId !== "number") {
+    return NextResponse.json({ error: "chainId must be a number" }, { status: 400 });
+  }
+
+  // Check if address is a contract (Safe wallet)
+  const isContract = await isContractAddress(address, chainId);
+
+  if (isContract) {
+    // Use Safe signature validation
+    const isValid = await validateSafeSignature({
+      chainId,
+      safeAddress: address,
+      message: messageType === "typed_data" ? JSON.parse(message) : message,
+      signature,
+      messageType,
+    });
+
+    if (!isValid) {
+      return NextResponse.json({ error: "Invalid signature" }, { status: 401 });
+    }
+  } else {
+    // Use standard EOA signature validation
+    const recoveredAddress =
+      messageType === "typed_data"
+        ? await recoverTypedDataAddress({ ...JSON.parse(message), signature })
+        : await recoverMessageAddress({ message, signature });
+
+    if (recoveredAddress !== address) {
+      return NextResponse.json({ error: "Invalid signature" }, { status: 401 });
+    }
   }
 
   const messageId = await createMessageWithSignature(message, messageType, signature, address);

--- a/packages/nextjs/app/page.tsx
+++ b/packages/nextjs/app/page.tsx
@@ -12,7 +12,7 @@ import { useAccount } from "wagmi";
 import { MessageType } from "~~/services/db/schema";
 
 const Home: NextPage = () => {
-  const { address } = useAccount();
+  const { address, chain } = useAccount();
   const router = useRouter();
   const [messageText, setMessageText] = useLocalStorage("messageText", "hello ethereum");
   const [typedData, setTypedData] = useLocalStorage("typedData", eip712Example);
@@ -42,7 +42,7 @@ const Home: NextPage = () => {
   }, [typedData]);
 
   const handleSignature = async (signature: string, message: string, messageType: MessageType) => {
-    if (!address) return;
+    if (!address || !chain) return;
 
     const res = await fetch("/api/signatures", {
       method: "POST",
@@ -54,6 +54,7 @@ const Home: NextPage = () => {
         message,
         messageType,
         address,
+        chainId: chain.id,
       }),
     });
 

--- a/packages/nextjs/app/view/[id]/page.tsx
+++ b/packages/nextjs/app/view/[id]/page.tsx
@@ -13,7 +13,7 @@ import { messagesTable, signaturesTable } from "~~/services/db/schema";
 
 const ViewSignature: NextPage<{ params: { id: string } }> = ({ params }: { params: { id: string } }) => {
   const { id } = params;
-  const { address } = useAccount();
+  const { address, chain } = useAccount();
   const { openConnectModal } = useConnectModal();
 
   const [message, setMessage] = useState<string | null>(null);
@@ -91,6 +91,10 @@ const ViewSignature: NextPage<{ params: { id: string } }> = ({ params }: { param
       setIsSubmitting(true);
       setError(null);
 
+      if (!chain) {
+        throw new Error("Chain not connected");
+      }
+
       const response = await fetch(`/api/signatures/${id}`, {
         method: "POST",
         headers: {
@@ -99,6 +103,7 @@ const ViewSignature: NextPage<{ params: { id: string } }> = ({ params }: { param
         body: JSON.stringify({
           signature,
           signer: address,
+          chainId: chain.id,
         }),
       });
 

--- a/packages/nextjs/utils/signatorio/detect-safe.ts
+++ b/packages/nextjs/utils/signatorio/detect-safe.ts
@@ -1,0 +1,37 @@
+import { type Address, createPublicClient, fallback, http } from "viem";
+import * as chains from "viem/chains";
+import { getAlchemyHttpUrl } from "~~/utils/scaffold-eth/networks";
+
+/**
+ * Detects if an address is a contract (Safe wallets are contracts)
+ * @param address - The address to check
+ * @param chainId - The chain ID to query
+ * @returns true if the address is a contract, false otherwise
+ */
+export const isContractAddress = async (address: Address, chainId: number): Promise<boolean> => {
+  try {
+    const alchemyHttpUrl = getAlchemyHttpUrl(chainId);
+    const rpcFallbacks = alchemyHttpUrl ? [http(alchemyHttpUrl), http()] : [http()];
+
+    // Find the chain from viem chains
+    const chainNames = Object.keys(chains);
+    const chain = chainNames.map(name => chains[name as keyof typeof chains]).find((c: any) => c?.id === chainId) as
+      | chains.Chain
+      | undefined;
+
+    if (!chain) {
+      throw new Error(`Unsupported chain ID: ${chainId}`);
+    }
+
+    const publicClient = createPublicClient({
+      chain,
+      transport: fallback(rpcFallbacks),
+    });
+
+    const bytecode = await publicClient.getBytecode({ address });
+    return bytecode !== undefined && bytecode !== "0x";
+  } catch (error) {
+    console.error("Error detecting contract address:", error);
+    return false;
+  }
+};

--- a/packages/nextjs/utils/signatorio/validate-safe-signature.ts
+++ b/packages/nextjs/utils/signatorio/validate-safe-signature.ts
@@ -1,0 +1,70 @@
+import Safe from "@safe-global/protocol-kit";
+import { hashSafeMessage } from "@safe-global/protocol-kit";
+import { hashMessage } from "viem";
+import type { Address } from "viem";
+import { getAlchemyHttpUrl } from "~~/utils/scaffold-eth/networks";
+
+export type EIP712TypedData = {
+  domain: {
+    name?: string;
+    version?: string;
+    chainId?: number;
+    verifyingContract?: string;
+  };
+  types: Record<string, Array<{ name: string; type: string }>>;
+  message: Record<string, any>;
+};
+
+/**
+ * Validates a Safe signature
+ * @param chainId - The chain ID where the Safe is deployed
+ * @param safeAddress - The Safe contract address
+ * @param message - The message (either string or typed data)
+ * @param signature - The signature to validate
+ * @param messageType - Type of message: "text" or "typed_data"
+ * @returns true if signature is valid, false otherwise
+ */
+export const validateSafeSignature = async ({
+  chainId,
+  safeAddress,
+  message,
+  signature,
+  messageType,
+}: {
+  chainId: number;
+  safeAddress: Address;
+  message: string | EIP712TypedData;
+  signature: string;
+  messageType: "text" | "typed_data";
+}): Promise<boolean> => {
+  try {
+    const providerUrl = getAlchemyHttpUrl(chainId);
+    if (!providerUrl) {
+      throw new Error(`No RPC URL available for chain ID ${chainId}`);
+    }
+
+    const protocolKit = await Safe.init({
+      provider: providerUrl,
+      safeAddress: safeAddress,
+    });
+
+    let safeMessage: string;
+
+    if (messageType === "typed_data") {
+      // For typed data, parse and hash it using Safe's hashSafeMessage
+      const typedData = typeof message === "string" ? JSON.parse(message) : message;
+      safeMessage = hashSafeMessage(typedData);
+    } else {
+      // For text messages, use standard EIP-191 message hashing
+      // Safe wallets sign regular messages using EIP-191 format
+      const messageText = typeof message === "string" ? message : JSON.stringify(message);
+      safeMessage = hashMessage(messageText);
+    }
+
+    const isValidSignature = await protocolKit.isValidSignature(safeMessage, signature);
+    return isValidSignature;
+  } catch (error) {
+    console.error("Error validating Safe signature:", error);
+    return false;
+  }
+};


### PR DESCRIPTION
Fixes #3 

This PR adds Safe support to Signatorio. You can sign messages and typedData with Safe... and see the verification.

e.g. with https://etherscan.io/address/0x4FD5480202Dad4d52EBc85D37f1cA01074791935

<img width="865" height="850" alt="image" src="https://github.com/user-attachments/assets/1f7c3926-60e0-4125-9ec1-4dcbdc994877" />
<img width="959" height="1026" alt="image" src="https://github.com/user-attachments/assets/2dc4ff6e-f3e8-44e5-a0ff-1e61e8b317eb" />
